### PR TITLE
Add protection-only event flag and config.ini support for driver flags

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -610,4 +610,4 @@ EG4_LL_CRC_CHECKSUM_LOGGER = False
 ;        expected to be crossed occasionally in normal operation.
 ; False: Both warning-level (1) and protection-level (2) alarms trigger an event.
 ; Valid values: True, False. Default: False.
-EG4_LL_PROTECTION_ONLY_EVENTS = False
+EG4_LL_PROTECTION_ONLY_EVENTS = True

--- a/config.ini
+++ b/config.ini
@@ -572,15 +572,42 @@ LIPRO_END_ADDRESS   = 4
 LIPRO_CELL_COUNT    = 15
 
 ; -- EG4_LL settings
-; Print battery stats to STDOut after each BMS poll.
+; Verbose polling output. Prints full battery stats to STDOut after every BMS poll (every
+; POLL_INTERVAL seconds), not just when something changes. Useful for live troubleshooting;
+; produces a lot of log volume if left on continuously.
+; Valid values: True, False. Default: False.
 EG4_LL_STATUS_LOGGER = False
-; Load BMS config on startup and use driver-based (config-defined) alarm thresholds instead of
-; relying solely on the BMS hardware alarm registers.
+
+; Alarm source selection. Controls where warning/protection thresholds and alarm state come from.
+; True:  Read the BMS's configured warning/protection thresholds on startup and evaluate alarms
+;        in the driver (EG4AlarmManager). This is what makes EG4_LL_PROTECTION_ONLY_EVENTS below
+;        effective, and is required for driver-managed FET control based on alarm severity.
+; False: Fall back to the BMS hardware alarm registers (protection_hex/warning_hex/error_hex) only.
+; Valid values: True, False. Default: True.
 EG4_LL_LOAD_BMS_SETTINGS = True
-; Print to STDOut when the BMS raises an error, warning, or protection event.
+
+; Error/event logging based on the BMS hardware alarm registers (protection_hex/warning_hex/
+; error_hex), independent of the driver-managed alarm evaluation. This fires whenever
+; EG4_LL_LOAD_BMS_SETTINGS is False, and also on polls where EG4_LL_LOAD_BMS_SETTINGS is True
+; but no new driver-level alarm transition occurred this cycle (e.g. an alarm is still active
+; from a prior poll) - so in practice it covers most polls while any alarm condition persists.
+; Valid values: True, False. Default: True. Turning this off can hide real BMS problems -
+; not recommended.
 EG4_LL_PROTECTION_LOGGER = True
-; Print to STDOut when a BMS reply fails the CRC checksum.
+
+; CRC checksum diagnostics. Prints to STDOut whenever a reply from the BMS fails its CRC
+; checksum (indicates RS-485 noise, wiring issues, or CH341 adapter instability). Purely
+; diagnostic - does not affect driver behavior.
+; Valid values: True, False. Default: False.
 EG4_LL_CRC_CHECKSUM_LOGGER = False
-; True: only protection-level alarms trigger events/logging; warning-level alarms are ignored.
-; False: both warning- and protection-level alarms trigger events/logging.
+
+; Event trigger severity. Controls which alarm severities cause the driver to log/trigger an
+; event when EG4_LL_LOAD_BMS_SETTINGS is True. Does not affect FET control (charge/discharge
+; is still blocked on protection-level alarms regardless of this setting).
+; True:  Only protection-level alarms (severity 2, e.g. cell over-voltage protection) trigger
+;        an event. Warning-level alarms (severity 1) are still tracked internally but do not
+;        log or trigger. Use this to reduce log noise from BMS warning thresholds that are
+;        expected to be crossed occasionally in normal operation.
+; False: Both warning-level (1) and protection-level (2) alarms trigger an event.
+; Valid values: True, False. Default: False.
 EG4_LL_PROTECTION_ONLY_EVENTS = False

--- a/config.ini
+++ b/config.ini
@@ -570,3 +570,17 @@ GREENMETER_ADDRESS  = 1
 LIPRO_START_ADDRESS = 2
 LIPRO_END_ADDRESS   = 4
 LIPRO_CELL_COUNT    = 15
+
+; -- EG4_LL settings
+; Print battery stats to STDOut after each BMS poll.
+EG4_LL_STATUS_LOGGER = False
+; Load BMS config on startup and use driver-based (config-defined) alarm thresholds instead of
+; relying solely on the BMS hardware alarm registers.
+EG4_LL_LOAD_BMS_SETTINGS = True
+; Print to STDOut when the BMS raises an error, warning, or protection event.
+EG4_LL_PROTECTION_LOGGER = True
+; Print to STDOut when a BMS reply fails the CRC checksum.
+EG4_LL_CRC_CHECKSUM_LOGGER = False
+; True: only protection-level alarms trigger events/logging; warning-level alarms are ignored.
+; False: both warning- and protection-level alarms trigger events/logging.
+EG4_LL_PROTECTION_ONLY_EVENTS = False

--- a/egll.py
+++ b/egll.py
@@ -43,13 +43,9 @@ class EG4_LL(Battery):
         self.data = {}
 
     statuslogger = utils.get_bool_from_config("DEFAULT", "EG4_LL_STATUS_LOGGER")  # Prints to STDOut After Each BMS Poll
-    LoadBMSSettings = utils.get_bool_from_config(
-        "DEFAULT", "EG4_LL_LOAD_BMS_SETTINGS"
-    )  # Load BMS Config on Startup && Use Driver Based Alarms
+    LoadBMSSettings = utils.get_bool_from_config("DEFAULT", "EG4_LL_LOAD_BMS_SETTINGS")  # Load BMS Config on Startup && Use Driver Based Alarms
     protectionLogger = utils.get_bool_from_config("DEFAULT", "EG4_LL_PROTECTION_LOGGER")  # Print to STDOut when BMS raises an error
-    crcchecksumlogger = utils.get_bool_from_config(
-        "DEFAULT", "EG4_LL_CRC_CHECKSUM_LOGGER"
-    )  # Print to stdout when the BMS Reply fails the CRC checksum
+    crcchecksumlogger = utils.get_bool_from_config("DEFAULT", "EG4_LL_CRC_CHECKSUM_LOGGER")  # Print to stdout when the BMS Reply fails the CRC checksum
     protectionOnlyEvents = utils.get_bool_from_config(
         "DEFAULT", "EG4_LL_PROTECTION_ONLY_EVENTS"
     )  # True: only protection-level (2) alarms trigger events/logging; warnings (1) are ignored

--- a/egll.py
+++ b/egll.py
@@ -42,10 +42,17 @@ class EG4_LL(Battery):
         self.runtime = 0  # TROUBLESHOOTING for no reply errors
         self.data = {}
 
-    statuslogger = False  # Prints to STDOut After Each BMS Poll
-    LoadBMSSettings = True  # Load BMS Config on Startup && Use Driver Based Alarms
-    protectionLogger = True  # Print to STDOut when BMS raises an error
-    crcchecksumlogger = False  # Print to stdout when the BMS Reply fails the CRC checksum
+    statuslogger = utils.get_bool_from_config("DEFAULT", "EG4_LL_STATUS_LOGGER")  # Prints to STDOut After Each BMS Poll
+    LoadBMSSettings = utils.get_bool_from_config(
+        "DEFAULT", "EG4_LL_LOAD_BMS_SETTINGS"
+    )  # Load BMS Config on Startup && Use Driver Based Alarms
+    protectionLogger = utils.get_bool_from_config("DEFAULT", "EG4_LL_PROTECTION_LOGGER")  # Print to STDOut when BMS raises an error
+    crcchecksumlogger = utils.get_bool_from_config(
+        "DEFAULT", "EG4_LL_CRC_CHECKSUM_LOGGER"
+    )  # Print to stdout when the BMS Reply fails the CRC checksum
+    protectionOnlyEvents = utils.get_bool_from_config(
+        "DEFAULT", "EG4_LL_PROTECTION_ONLY_EVENTS"
+    )  # True: only protection-level (2) alarms trigger events/logging; warnings (1) are ignored
 
     battery_stats = {}
     serialTimeout = 2  # Serial Connection timeout
@@ -198,7 +205,8 @@ class EG4_LL(Battery):
             return True
         # Log when driver-level alarm state changes (after update_alarm_dbus so protection attrs are current)
         if self.LoadBMSSettings is True and self.alarm_mgr._alarms_changed:
-            active_alarms = {k: v for k, v in alarm_status.items() if v != 0}
+            trigger_level = 2 if self.protectionOnlyEvents else 1
+            active_alarms = {k: v for k, v in alarm_status.items() if v >= trigger_level}
             if active_alarms:
                 logger.error("** BMS Error, Protect or Warning Event Code Found In Polling Cycle **")
                 self.eg4ll_logger(bank_stats, 2, active_alarms)


### PR DESCRIPTION
## Summary
- Adds `EG4_LL_PROTECTION_ONLY_EVENTS` to suppress warning-level alarms from triggering driver events/logging while still tracking them internally and leaving FET control unaffected (still reacts to protection-level alarms regardless).
- Moves the driver's logging/alarm-behavior flags (`statuslogger`, `LoadBMSSettings`, `protectionLogger`, `crcchecksumlogger`, `protectionOnlyEvents`) from hardcoded class attributes to `config.ini`, via `utils.get_bool_from_config`, so they're tunable without editing `egll.py`.
- Deployed config sets `EG4_LL_PROTECTION_ONLY_EVENTS = True` to cut log noise from recurring `Cell_OV` warnings (cells sitting near the 3.6V warning threshold) while keeping protection-level alerting intact.

## Test plan
- [x] Deployed to Cerbo, restarted driver, confirmed both BMS (`0x01`, `0x10`) reconnect cleanly with `CHARGE FET: True | DISCHARGE FET: True`
- [x] Confirmed `LoadBMSSettings`/`protectionLogger` correctly read `True` from config (no silent fallback to `False`)
- [x] Confirmed no `CONFIG ISSUES DETECTED` warnings after companion `config.default.ini` update in the `venus-os_dbus-serialbattery` fork
- [x] Confirmed `EG4_LL_PROTECTION_ONLY_EVENTS = True` deployed and driver restarts cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)