### PR TITLE
Remove EG4_LL_PROTECTION_ONLY_EVENTS from config.ini, hardcode to True

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -580,8 +580,8 @@ EG4_LL_STATUS_LOGGER = False
 
 ; Alarm source selection. Controls where warning/protection thresholds and alarm state come from.
 ; True:  Read the BMS's configured warning/protection thresholds on startup and evaluate alarms
-;        in the driver (EG4AlarmManager). This is what makes EG4_LL_PROTECTION_ONLY_EVENTS below
-;        effective, and is required for driver-managed FET control based on alarm severity.
+;        in the driver (EG4AlarmManager), which is required for driver-managed FET control
+;        based on alarm severity.
 ; False: Fall back to the BMS hardware alarm registers (protection_hex/warning_hex/error_hex) only.
 ; Valid values: True, False. Default: True.
 EG4_LL_LOAD_BMS_SETTINGS = True
@@ -600,14 +600,3 @@ EG4_LL_PROTECTION_LOGGER = True
 ; diagnostic - does not affect driver behavior.
 ; Valid values: True, False. Default: False.
 EG4_LL_CRC_CHECKSUM_LOGGER = False
-
-; Event trigger severity. Controls which alarm severities cause the driver to log/trigger an
-; event when EG4_LL_LOAD_BMS_SETTINGS is True. Does not affect FET control (charge/discharge
-; is still blocked on protection-level alarms regardless of this setting).
-; True:  Only protection-level alarms (severity 2, e.g. cell over-voltage protection) trigger
-;        an event. Warning-level alarms (severity 1) are still tracked internally but do not
-;        log or trigger. Use this to reduce log noise from BMS warning thresholds that are
-;        expected to be crossed occasionally in normal operation.
-; False: Both warning-level (1) and protection-level (2) alarms trigger an event.
-; Valid values: True, False. Default: False.
-EG4_LL_PROTECTION_ONLY_EVENTS = True

--- a/egll.py
+++ b/egll.py
@@ -46,9 +46,7 @@ class EG4_LL(Battery):
     LoadBMSSettings = utils.get_bool_from_config("DEFAULT", "EG4_LL_LOAD_BMS_SETTINGS")  # Load BMS Config on Startup && Use Driver Based Alarms
     protectionLogger = utils.get_bool_from_config("DEFAULT", "EG4_LL_PROTECTION_LOGGER")  # Print to STDOut when BMS raises an error
     crcchecksumlogger = utils.get_bool_from_config("DEFAULT", "EG4_LL_CRC_CHECKSUM_LOGGER")  # Print to stdout when the BMS Reply fails the CRC checksum
-    protectionOnlyEvents = utils.get_bool_from_config(
-        "DEFAULT", "EG4_LL_PROTECTION_ONLY_EVENTS"
-    )  # True: only protection-level (2) alarms trigger events/logging; warnings (1) are ignored
+    protectionOnlyEvents = True  # True: only protection-level (2) alarms trigger events/logging; warnings (1) are ignored
 
     battery_stats = {}
     serialTimeout = 2  # Serial Connection timeout


### PR DESCRIPTION
## Summary
- Removes `EG4_LL_PROTECTION_ONLY_EVENTS` as a `config.ini` option and hardcodes `protectionOnlyEvents = True` directly in `egll.py`.
- Unlike the other `EG4_LL_*` flags (which are genuine either-way preferences), this one we always want enabled and explicitly documented as such — exposing it as a toggle only invited accidental misconfiguration.
- Fixes a dangling doc reference in the `EG4_LL_LOAD_BMS_SETTINGS` comment that pointed at the now-removed option.

## Test plan
- [x] Deployed directly to Cerbo (driver + both config files), restarted, confirmed clean startup with no `CONFIG ISSUES DETECTED` warnings
- [x] Confirmed both BMS (`0x01`, `0x10`) reconnect with `CHARGE FET: True | DISCHARGE FET: True`
- [x] Confirmed `egll.py` syntax compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)